### PR TITLE
Refactored build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /tests/test_resources
+~
+build.ds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bhop"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bhop"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Shane Stephenson <stephenson.shane.a@gmail.com>"]
 readme = "README.md"
@@ -25,6 +25,10 @@ colored = "2.0.0"
 serial_test = "1.0.0"
 tempdir = "0.3.7"
 proceed = "0.1.0"
+
+[build-dependencies]
+dirs = "4.0.0"
+anyhow = "1.0"
 
 [[bin]]
 name = "bhop"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This iteration also includes many improvements over the very simple shell functi
 ### HOW TO INSTALL
 Simply clone this repo and run `make` from the root repo directory.
 
-Current install script that works on the most systems with the most shells requires a system install of `python3` and `cargo`.
+Current install script that works on the most systems with the most shells requires a system install `cargo` (obvi, since it's a tool written in Rust).
 
 If you currently don't have `rust` or `cargo` set up on your system, just run the following command before installing `bunnyhop`
 ```bash
@@ -39,7 +39,7 @@ Once `cargo` is installed, simply run the following to install `bunnyhop`:
 ```bash
 git clone https://github.com/gnoat/hop.github
 cd hop
-make all
+cargo build --release
 ```
 The default runner alias set is `hp`, use this to call `bunnyhop` from the command line (unless you set a custom alias).
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+#[path = "runners/add_runners.rs"]
+mod add_runners;
+use add_runners::{
+    Runners,
+    Shell::{Bash, Nushell, Powershell, Zsh},
+};
+
+fn main() {
+    println!("Building Bunnyhop version {}", env!("CARGO_PKG_VERSION"));
+    for script in ["add_runners.rs", "runner.ps1", "runner.sh", "runner.nu"].iter() {
+        println!("cargo:rerun-if-changed=runners/{}", script);
+    }
+    for env_var in [
+        "BUNNYHOP_ZSH_CONFIG_DIR",
+        "BUNNYHOP_BASH_CONFIG_DIR",
+        "BUNNYHOP_NUSHELL_CONFIG_DIR",
+        "BUNNYHOP_POWERSHELL_CONFIG_DIR",
+    ]
+    .iter()
+    {
+        println!("cargo:rerun-if-env-changed={}", env_var);
+    }
+
+    let supported_shells = vec![Zsh, Bash, Nushell, Powershell];
+    let runners = Runners::new(supported_shells);
+    runners.add_runners();
+}

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,8 @@ fn main() {
         println!("cargo:rerun-if-env-changed={}", env_var);
     }
 
+    // Any new shells added in the future must be added in the following vector to be properly
+    // configured with their respective runner script when `Bunnyhop` is built.
     let supported_shells = vec![Zsh, Bash, Nushell, Powershell];
     let runners = Runners::new(supported_shells);
     runners.add_runners();

--- a/runners/add_runners.rs
+++ b/runners/add_runners.rs
@@ -5,12 +5,27 @@
 // it will run all necessary commands and print the text output.
 //
 // To add functionality for a new shell, the following need to be added:
-//  1) New runner in the language of the new shell in the `runners` folder.
+//  1) New runner in the language of the new shell in the `runners` folder that matches the pattern
+//     of `runner.{ext}`, where `ext` is the file format extension of shell scripts for the new
+//     shell being added.
 //  2) New shell added to the `Shell` enum.
-//  3) New `ShellMetadata` entry for new enum variant.
-//  4) New function within `ShellMetadata` to locate the default configuration file for the new
-//     shell if the default configuration file for the new shell is not the user's home directory.
-//  5) New enum variant needs to be added to `build.rs` where the `Runners` struct is created.
+//  3) `Shell` enum implementations must be updated for each of the following methods to provide
+//     the appropriate metadata for the new shell being added (if it isn't the same as the default
+//     method output):
+//          a) call_cmd
+//          b) source_cmd
+//          c) name
+//          d) env_var
+//          e) ext
+//          f) script
+//          g) config_dir
+//          h) config_name
+//          i) find_default
+//  4) New `Shell` method for deriving most probable default shell configuration file for the shell
+//     being added will need to be created if the default shell configuration file is not in the
+//     user's home directory.
+//  5) New `Shell` enum variant needs to be added to `build.rs` in the vector of shells where being
+//     fed into the `Runner`.
 //
 // With all these updates in place, the current build system should start configuring the new shell
 // for use.
@@ -30,114 +45,125 @@ pub enum Shell {
     Powershell,
 }
 
-#[derive(Clone)]
-pub struct ShellMetadata<'a, 'b> {
-    shell: &'b Shell,
-    call_cmd: &'a str,
-    source_cmd: &'a str,
-    name: &'a str,
-    env_var: &'a str,
-    ext: &'a str,
-    script: &'a str,
-    config_dir: &'a str,
-    config_name: &'a str,
-}
+impl Shell {
+    // These are the foundational methods that need to be implemented for each new shell runner
+    // support is being added for.
+    fn call_cmd(&self) -> &str {
+        // This method returns the command used to call shell commands in this from any other shell.
+        match self {
+            Shell::Zsh => "zsh",
+            Shell::Bash => "sh",
+            Shell::Nushell => "nu",
+            Shell::Powershell => "powershell",
+        }
+    }
 
-impl<'a, 'b> ShellMetadata<'a, 'b> {
-    pub fn new(shell: &'b Shell) -> Self {
-        match *shell {
-            Shell::Zsh => ShellMetadata {
-                shell,
-                call_cmd: "zsh",
-                source_cmd: "source",
-                name: "ZSH",
-                env_var: "BUNNYHOP_ZSH_CONFIG_DIR",
-                ext: "sh",
-                script: include_str!("runner.sh"),
-                config_dir: "ZDOTDIR",
-                config_name: ".zshrc",
-            },
-            Shell::Bash => ShellMetadata {
-                shell,
-                call_cmd: "sh",
-                source_cmd: "source",
-                name: "BASH",
-                env_var: "BUNNYHOP_BASH_CONFIG_DIR",
-                ext: "sh",
-                script: include_str!("runner.sh"),
-                config_dir: "HOME",
-                config_name: ".bashrc",
-            },
-            Shell::Nushell => ShellMetadata {
-                shell,
-                call_cmd: "nu",
-                source_cmd: "source",
-                name: "NUSHELL",
-                env_var: "BUNNYHOP_NUSHELL_CONFIG_DIR",
-                ext: "nu",
-                script: include_str!("runner.nu"),
-                config_dir: "nu.env-path",
-                config_name: "env.nu",
-            },
-            Shell::Powershell => ShellMetadata {
-                shell,
-                call_cmd: "powershell",
-                source_cmd: ".",
-                name: "POWERSHELL",
-                env_var: "BUNNYHOP_POWERSHELL_CONFIG_DIR",
-                ext: "ps1",
-                script: include_str!("runner.ps1"),
-                config_dir: "profile",
-                config_name: "Microsoft.Powershell_profile.ps1",
-            },
+    fn source_cmd(&self) -> &str {
+        // This method returns the command used to source another file in a shell's config file.
+        match self {
+            Shell::Nushell => "source",
+            _ => ".",
+        }
+    }
+
+    fn name(&self) -> &str {
+        // This method returns the proper name of the shell.
+        match self {
+            Shell::Zsh => "ZSH",
+            Shell::Bash => "BASH",
+            Shell::Nushell => "NUSHELL",
+            Shell::Powershell => "POWERSHELL",
+        }
+    }
+
+    fn env_var(&self) -> &str {
+        // This method returns the environment variable that can be set to specify a non-standard
+        // shell configuration file location.
+        match self {
+            Shell::Zsh => "BUNNYHOP_ZSH_CONFIG_DIR",
+            Shell::Bash => "BUNNYHOP_BASH_CONFIG_DIR",
+            Shell::Nushell => "BUNNYHOP_NUSHELL_CONFIG_DIR",
+            Shell::Powershell => "BUNNYHOP_POWERSHELL_CONFIG_DIR",
+        }
+    }
+
+    fn ext(&self) -> &str {
+        // This method returns the file format extension of saved shell scripts for each shell.
+        match self {
+            Shell::Nushell => "nu",
+            Shell::Powershell => "ps1",
+            _ => "sh",
+        }
+    }
+
+    fn script(&self) -> &str {
+        // This method returns the specific implementation script for the runners in their
+        // respective shells.  Any new shells added will need an appropriate runner implementation
+        // added.
+        match self {
+            Shell::Nushell => include_str!("runner.nu"),
+            Shell::Powershell => include_str!("runner.ps1"),
+            _ => include_str!("runner.sh"),
+        }
+    }
+
+    fn config_dir(&self) -> &str {
+        // This method returns the the configuration file or the directory the configuration file
+        // is in when called as variables within their respective shells.
+        //
+        // For example, in Zsh if
+        // you call `zsh -c "echo $ZDOTDIR"`, it will return the current configuration directory
+        // that .zshrc is in or it will return an empty string.
+        //
+        // Similarly, `nu -c "echo $nu.env-path"` and `powershell -c "echo $profile"` will both
+        // return the path to their direct configuration files that need to be updated.
+        match self {
+            Shell::Zsh => "ZDOTDIR",
+            Shell::Bash => "HOME",
+            Shell::Nushell => "nu.env-path",
+            Shell::Powershell => "profile",
+        }
+    }
+
+    fn config_name(&self) -> &str {
+        // This method returns the default name of the configuration file for each shell that will
+        // need to be updated.  This is used to parse the shell configuration file when the above
+        // used commands fail or return nothing.
+        match self {
+            Shell::Zsh => ".zshrc",
+            Shell::Bash => ".bashrc",
+            Shell::Nushell => "env.nu",
+            Shell::Powershell => "Microsoft.Powershell_profile.ps1",
         }
     }
 
     fn find_default(&self) -> Option<PathBuf> {
-        match self.shell {
+        // This method points to the specific implementations for determining the shell
+        // configuration file for each shell.
+        //
+        // Zsh and Bash are relatively simple because they are
+        // in the same location on almost every operating system.
+        //
+        // Nushell's default location varies between operating systems
+        // and Powershell's varies not only between operating
+        // systems but between different configurations of Windows itself.
+        //
+        // If the configuration file for any new shell being added doesn't default to a user's home
+        // directory, a new method will have to be implemented and to derive the default
+        // shell configuration path and it will have to be pointed to in this method.
+        match self {
             Shell::Nushell => self.nushell_default(),
             Shell::Powershell => self.powershell_default(),
             _ => self.home_default(),
         }
     }
+}
 
-    pub fn derive_config_path(&self) -> Option<PathBuf> {
-        let from_env = var(self.env_var);
-        match from_env {
-            Ok(p) => Some(PathBuf::from(&p)),
-            Err(_) => match Command::new(self.call_cmd)
-                .arg("-c")
-                .arg(format!("echo ${}", &self.config_dir))
-                .output()
-            {
-                Ok(out) => match String::from_utf8(out.stdout) {
-                    Ok(p) => {
-                        let derived = p.trim();
-                        if !derived.is_empty() {
-                            // the below is slightly more convoluted that I think it should be, but
-                            // it's this way because calling `bash -c "echo $HOME"` and `sh -c "echo $HOME"`
-                            // on Windows sucks and returns path strings unparsable by PathBuf
-                            // depending on which implementation you're using (the two that I
-                            // primarily use, Ubuntu WSL and Git-Bash both return completely
-                            // different bad paths).
-                            let derived_path = PathBuf::from(&derived);
-                            if derived_path.is_file() {
-                                return Some(derived_path);
-                            } else if derived_path.is_dir() {
-                                return Some(derived_path.as_path().join(self.config_name));
-                            }
-                        }
-                        self.find_default()
-                    }
-                    Err(_) => self.find_default(),
-                },
-                Err(_) => self.find_default(),
-            },
-        }
-    }
-
+impl Shell {
+    // These implementations are collections of methods for determining the default path for each
+    // shell's configuration file.
     fn home_default(&self) -> Option<PathBuf> {
-        home_dir().map(|home| home.join(self.config_name))
+        home_dir().map(|home| home.join(self.config_name()))
     }
 
     fn nushell_default(&self) -> Option<PathBuf> {
@@ -162,7 +188,7 @@ impl<'a, 'b> ShellMetadata<'a, 'b> {
                             home.join("OneDrive")
                                 .join("Documents")
                                 .join("WindowsPowerShell")
-                                .join(self.config_name),
+                                .join(self.config_name()),
                         )
                     } else {
                         Some(
@@ -184,6 +210,46 @@ impl<'a, 'b> ShellMetadata<'a, 'b> {
     }
 }
 
+impl Shell {
+    // These methods combine all other methods together to determine (where possible) the best
+    // guess shell configuration path if a specific configuration path isn't specified through
+    // environment variables.
+    pub fn derive_config_path(&self) -> Option<PathBuf> {
+        let from_env = var(self.env_var());
+        match from_env {
+            Ok(p) => Some(PathBuf::from(&p)),
+            Err(_) => match Command::new(self.call_cmd())
+                .arg("-c")
+                .arg(format!("echo ${}", &self.config_dir()))
+                .output()
+            {
+                Ok(out) => match String::from_utf8(out.stdout) {
+                    Ok(p) => {
+                        let derived = p.trim();
+                        if !derived.is_empty() {
+                            // the below is slightly more convoluted that I think it should be, but
+                            // it's this way because calling `bash -c "echo $HOME"` and `sh -c "echo $HOME"`
+                            // on Windows sucks and returns path strings unparsable by PathBuf
+                            // depending on which implementation you're using (the two that I
+                            // primarily use, Ubuntu WSL and Git-Bash both return completely
+                            // different bad paths).
+                            let derived_path = PathBuf::from(&derived);
+                            if derived_path.is_file() {
+                                return Some(derived_path);
+                            } else if derived_path.is_dir() {
+                                return Some(derived_path.as_path().join(self.config_name()));
+                            }
+                        }
+                        self.find_default()
+                    }
+                    Err(_) => self.find_default(),
+                },
+                Err(_) => self.find_default(),
+            },
+        }
+    }
+}
+
 pub struct Runners {
     alias: String,
     shells: Vec<Shell>,
@@ -200,18 +266,21 @@ impl Runners {
 
     pub fn add_runners(&self) {
         for shell in self.shells.iter() {
-            let shell_meta = ShellMetadata::new(shell);
-            match self.add_runner(&shell_meta) {
-                Ok(_) => println!("Runner successfully added for {}.", shell_meta.name),
-                Err(e) => println!("Failed to add runner for {}, error: {}", shell_meta.name, e),
+            match self.add_runner(shell) {
+                Ok(_) => println!("Runner successfully added for {}.", shell.name()),
+                Err(e) => println!("Failed to add runner for {}, error: {}", shell.name(), e),
             }
         }
     }
 
-    fn add_runner(&self, shell: &ShellMetadata) -> anyhow::Result<()> {
+    fn add_runner(&self, shell: &Shell) -> anyhow::Result<()> {
+        // This is the meat-and-potatoes method that actually does all the necessary imputation to
+        // create a working runner function for a shell and add it to the configuration file for
+        // the shell.
         println!(
             "[info] Adding runner `{}` to shell {}",
-            &self.alias, shell.name
+            &self.alias,
+            shell.name()
         );
         match shell.derive_config_path() {
             Some(config_path) => {
@@ -219,7 +288,7 @@ impl Runners {
                 let config_file_path = config_path
                     .parent()
                     .unwrap()
-                    .join(format!(".bunnyhop.{}", &shell.ext));
+                    .join(format!(".bunnyhop.{}", &shell.ext()));
                 let mut hop_conf_file = OpenOptions::new()
                     .write(true)
                     .create(true)
@@ -243,12 +312,12 @@ impl Runners {
                     .replace('\\', "/");
                 let source_cmd = format!(
                     "{} \"{}\"",
-                    shell.source_cmd,
+                    shell.source_cmd(),
                     &config_file_path.as_path().display()
                 )
                 .replace('\\', "/");
                 let script = shell
-                    .script
+                    .script()
                     .replace("__HOPPERCMD__", &exe_path)
                     .replace("__FUNCTION_ALIAS__", &self.alias);
                 hop_conf_file.write_all(script.as_bytes())?;
@@ -258,7 +327,7 @@ impl Runners {
                 }
                 Ok(())
             }
-            None => anyhow::bail!(format!("Unable to add runner for {}.", &shell.name)),
+            None => anyhow::bail!(format!("Unable to add runner for {}.", &shell.name())),
         }
     }
 }

--- a/runners/add_runners.rs
+++ b/runners/add_runners.rs
@@ -1,0 +1,264 @@
+// Build script that will detect shells on your system and add runner functions for those shells to
+// their configuration files.  These runners are needed because it's otherwise impossible to change
+// directories in the terminal without executing `cd` as a shell command.  The runner functions
+// basically just check to see if it's a `cd` command, some other type of command, or just text and
+// it will run all necessary commands and print the text output.
+//
+// To add functionality for a new shell, the following need to be added:
+//  1) New runner in the language of the new shell in the `runners` folder.
+//  2) New shell added to the `Shell` enum.
+//  3) New `ShellMetadata` entry for new enum variant.
+//  4) New function within `ShellMetadata` to locate the default configuration file for the new
+//     shell if the default configuration file for the new shell is not the user's home directory.
+//  5) New enum variant needs to be added to `build.rs` where the `Runners` struct is created.
+//
+// With all these updates in place, the current build system should start configuring the new shell
+// for use.
+use dirs::home_dir;
+use std::{
+    env::var,
+    fs::{read_to_string, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub enum Shell {
+    Zsh,
+    Bash,
+    Nushell,
+    Powershell,
+}
+
+#[derive(Clone)]
+pub struct ShellMetadata<'a, 'b> {
+    shell: &'b Shell,
+    call_cmd: &'a str,
+    source_cmd: &'a str,
+    name: &'a str,
+    env_var: &'a str,
+    ext: &'a str,
+    script: &'a str,
+    config_dir: &'a str,
+    config_name: &'a str,
+}
+
+impl<'a, 'b> ShellMetadata<'a, 'b> {
+    pub fn new(shell: &'b Shell) -> Self {
+        match *shell {
+            Shell::Zsh => ShellMetadata {
+                shell,
+                call_cmd: "zsh",
+                source_cmd: "source",
+                name: "ZSH",
+                env_var: "BUNNYHOP_ZSH_CONFIG_DIR",
+                ext: "sh",
+                script: include_str!("runner.sh"),
+                config_dir: "ZDOTDIR",
+                config_name: ".zshrc",
+            },
+            Shell::Bash => ShellMetadata {
+                shell,
+                call_cmd: "sh",
+                source_cmd: "source",
+                name: "BASH",
+                env_var: "BUNNYHOP_BASH_CONFIG_DIR",
+                ext: "sh",
+                script: include_str!("runner.sh"),
+                config_dir: "HOME",
+                config_name: ".bashrc",
+            },
+            Shell::Nushell => ShellMetadata {
+                shell,
+                call_cmd: "nu",
+                source_cmd: "source",
+                name: "NUSHELL",
+                env_var: "BUNNYHOP_NUSHELL_CONFIG_DIR",
+                ext: "nu",
+                script: include_str!("runner.nu"),
+                config_dir: "nu.env-path",
+                config_name: "env.nu",
+            },
+            Shell::Powershell => ShellMetadata {
+                shell,
+                call_cmd: "powershell",
+                source_cmd: ".",
+                name: "POWERSHELL",
+                env_var: "BUNNYHOP_POWERSHELL_CONFIG_DIR",
+                ext: "ps1",
+                script: include_str!("runner.ps1"),
+                config_dir: "profile",
+                config_name: "Microsoft.Powershell_profile.ps1",
+            },
+        }
+    }
+
+    fn find_default(&self) -> Option<PathBuf> {
+        match self.shell {
+            Shell::Nushell => self.nushell_default(),
+            Shell::Powershell => self.powershell_default(),
+            _ => self.home_default(),
+        }
+    }
+
+    pub fn derive_config_path(&self) -> Option<PathBuf> {
+        let from_env = var(self.env_var);
+        match from_env {
+            Ok(p) => Some(PathBuf::from(&p)),
+            Err(_) => match Command::new(self.call_cmd)
+                .arg("-c")
+                .arg(format!("echo ${}", &self.config_dir))
+                .output()
+            {
+                Ok(out) => match String::from_utf8(out.stdout) {
+                    Ok(p) => {
+                        let derived = p.trim();
+                        if !derived.is_empty() {
+                            // the below is slightly more convoluted that I think it should be, but
+                            // it's this way because calling `bash -c "echo $HOME"` and `sh -c "echo $HOME"`
+                            // on Windows sucks and returns path strings unparsable by PathBuf
+                            // depending on which implementation you're using (the two that I
+                            // primarily use, Ubuntu WSL and Git-Bash both return completely
+                            // different bad paths).
+                            let derived_path = PathBuf::from(&derived);
+                            if derived_path.is_file() {
+                                return Some(derived_path);
+                            } else if derived_path.is_dir() {
+                                return Some(derived_path.as_path().join(self.config_name));
+                            }
+                        }
+                        self.find_default()
+                    }
+                    Err(_) => self.find_default(),
+                },
+                Err(_) => self.find_default(),
+            },
+        }
+    }
+
+    fn home_default(&self) -> Option<PathBuf> {
+        home_dir().map(|home| home.join(self.config_name))
+    }
+
+    fn nushell_default(&self) -> Option<PathBuf> {
+        if cfg!(windows) {
+            home_dir().map(|home| {
+                home.join("AppData")
+                    .join("Roaming")
+                    .join("nushell")
+                    .join("env.nu")
+            })
+        } else {
+            home_dir().map(|home| home.join("config").join("nushell").join("env.nu"))
+        }
+    }
+
+    fn powershell_default(&self) -> Option<PathBuf> {
+        if cfg!(windows) {
+            match home_dir() {
+                Some(home) => {
+                    if home.join("OneDrive").exists() {
+                        Some(
+                            home.join("OneDrive")
+                                .join("Documents")
+                                .join("WindowsPowerShell")
+                                .join(self.config_name),
+                        )
+                    } else {
+                        Some(
+                            home.join("Documents")
+                                .join("WindowsPowerShell")
+                                .join("Microsoft.PowerShell_profile.ps1"),
+                        )
+                    }
+                }
+                None => None,
+            }
+        } else {
+            home_dir().map(|home| {
+                home.join(".config")
+                    .join("powershell")
+                    .join("Microsoft.Powershell_profile.ps1")
+            })
+        }
+    }
+}
+
+pub struct Runners {
+    alias: String,
+    shells: Vec<Shell>,
+}
+
+impl Runners {
+    pub fn new(shells: Vec<Shell>) -> Self {
+        let alias = match var("BUNNYHOP_SHELL_ALIAS") {
+            Ok(n) => n,
+            Err(_) => "hp".to_string(),
+        };
+        Runners { alias, shells }
+    }
+
+    pub fn add_runners(&self) {
+        for shell in self.shells.iter() {
+            let shell_meta = ShellMetadata::new(shell);
+            match self.add_runner(&shell_meta) {
+                Ok(_) => println!("Runner successfully added for {}.", shell_meta.name),
+                Err(e) => println!("Failed to add runner for {}, error: {}", shell_meta.name, e),
+            }
+        }
+    }
+
+    fn add_runner(&self, shell: &ShellMetadata) -> anyhow::Result<()> {
+        println!(
+            "[info] Adding runner `{}` to shell {}",
+            &self.alias, shell.name
+        );
+        match shell.derive_config_path() {
+            Some(config_path) => {
+                println!("[info] Located config file: {}", &config_path.display());
+                let config_file_path = config_path
+                    .parent()
+                    .unwrap()
+                    .join(format!(".bunnyhop.{}", &shell.ext));
+                let mut hop_conf_file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(&config_file_path)?;
+                let mut conf_file = OpenOptions::new()
+                    .append(true)
+                    .read(true)
+                    .create(true)
+                    .open(&config_path)?;
+                let exe_parent_dir = if cfg!(debug_assertions) {
+                    "debug"
+                } else {
+                    "release"
+                };
+                let exe_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("target")
+                    .join(exe_parent_dir)
+                    .join("bhop")
+                    .display()
+                    .to_string()
+                    .replace('\\', "/");
+                let source_cmd = format!(
+                    "{} \"{}\"",
+                    shell.source_cmd,
+                    &config_file_path.as_path().display()
+                )
+                .replace('\\', "/");
+                let script = shell
+                    .script
+                    .replace("__HOPPERCMD__", &exe_path)
+                    .replace("__FUNCTION_ALIAS__", &self.alias);
+                hop_conf_file.write_all(script.as_bytes())?;
+                let config_file_contents = read_to_string(config_path)?;
+                if !config_file_contents.contains(&source_cmd) {
+                    conf_file.write_all(format!("\n{}", source_cmd).as_bytes())?;
+                }
+                Ok(())
+            }
+            None => anyhow::bail!(format!("Unable to add runner for {}.", &shell.name)),
+        }
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -40,8 +40,8 @@ impl Rabbit {
     pub fn request(input: String) -> Self {
         let input_path = PathBuf::from(&input);
         if input_path.exists()
-            && (&input.len() == &input.replace("/", "").len())
-            && (&input.len() == &input.replace("\\", "").len())
+            && (input == input.replace('/', ""))
+            && (input == input.replace('\\', ""))
         {
             Rabbit::RequestAmbiguous(input, input_path)
         } else if input_path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use bhop;
-
 fn main() {
     let command = bhop::args::Cmd::parse();
     let hopper = bhop::Hopper::new();


### PR DESCRIPTION
- All necessary runner script creation and sourcing is done in pure Rust and run within `build.rs` now
- I've currently left the old Python build script and Makefiles in the directory while I continue testing, but if there are no issues they will be removed in future version.